### PR TITLE
Fix "RuntimeConfig" 500's error

### DIFF
--- a/src/runtime/server/middleware/guard.ts
+++ b/src/runtime/server/middleware/guard.ts
@@ -1,5 +1,6 @@
 import { getSessionFromServer } from "../utils/getSessionFromServer"
 import { defineEventHandler, parseCookies, sendRedirect } from "h3";
+import { useRuntimeConfig } from "#imports";
 
 export default defineEventHandler(async (event) => {
   const runtimeConfig = useRuntimeConfig()


### PR DESCRIPTION
In the most recent version of Nuxt.JS 3, an error 500 appears when using the server middleware. Adding the "useRuntimeConfig" line corrects the problem.